### PR TITLE
Correct style name

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Available colors:
 Available styles:
 - bold
 - dim
-- undelined
+- underline
 - blink
 - reverse
 - hidden

--- a/chalk.v
+++ b/chalk.v
@@ -44,7 +44,7 @@ const (
     Style = {
         'bold': 1
         'dim': 2
-        'undelined': 4
+        'underline': 4
         'blink': 5
         'reverse': 7
         'hidden': 8


### PR DESCRIPTION
`undelined` (underlined with a typo) to `underline`